### PR TITLE
Drop @obsolete & @raw-io system calls

### DIFF
--- a/data/fwupd.service.in
+++ b/data/fwupd.service.in
@@ -33,5 +33,5 @@ RestrictRealtime=yes
 RestrictSUIDSGID=yes
 SystemCallArchitectures=native
 SystemCallErrorNumber=EPERM
-SystemCallFilter=~@clock @cpu-emulation @debug @module @mount
+SystemCallFilter=~@clock @cpu-emulation @debug @module @mount @obsolete @raw-io
 @dynamic_options@


### PR DESCRIPTION
This drops the @obsolete and @raw-io system calls for fwupd.

@obsolete covers unusual, obsolete or unimplemented system calls. 
@raw-io covers raw I/O port access.

Source: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html

Further details of calls contained within groups will be listed in the comments.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
